### PR TITLE
security: pin shivammathur/setup-php to v2.37.1

### DIFF
--- a/.github/workflows/ter-release.yml
+++ b/.github/workflows/ter-release.yml
@@ -22,7 +22,7 @@ jobs:
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@v2.37.1
         with:
           php-version: '7.4'
           extensions: intl, mbstring, xml, soap, zip, curl


### PR DESCRIPTION
Addresses [GHSA-5wxr-w449-57cm](https://github.com/advisories/GHSA-5wxr-w449-57cm) — earlier setup-php versions could leak the GitHub token through pinned-but-affected Composer versions.

Pins `shivammathur/setup-php` from `@v2` (floating) to `@v2.37.1`.

Closes Dependabot alert #10.